### PR TITLE
Make script run forever so it works with rancher2

### DIFF
--- a/tilesets/Dockerfile
+++ b/tilesets/Dockerfile
@@ -1,5 +1,5 @@
 # Use following version of node alpine as the base image
-FROM node:10-alpine
+FROM node:14-alpine
 
 # Set work directory for run/cmd
 WORKDIR /app

--- a/tilesets/README.md
+++ b/tilesets/README.md
@@ -13,7 +13,7 @@ The service can download or delete a tileset. It is designed to run once on a si
     "url": "https://openmaptiles.com/download/.eJwFwcERwCAIBMBefMvMCacJtWTyECL9l5Ddp23cLCIlToawQHHVkGuY2UoMsFpv27y4ywUrphAGucNT8CGXu-ZZs_VBur4_m44VEg.XSNhSQ.yP4kLh3nZelCDDTMnG_H_I9DDV8/osm-2019-06-24-v3.10-planet.mbtiles",
     "filename": "openmaptiles-2019-06-24-v3.10-planet.mbtiles",
     "delete": false,
-    "download": true,
+    "download": false,
     "size": 66330000000
   },
   "contours": {

--- a/tilesets/build-docker.sh
+++ b/tilesets/build-docker.sh
@@ -2,11 +2,11 @@
 DOCKER_IMAGE_NAME="q-locator-map-tilesets"
 DOCKER_TAG="dev"
 echo "DOCKER TAG is '$DOCKER_TAG'"
-read -p "docker username:" DOCKER_USERNAME
-read -s -p "docker password: " DOCKER_PASSWORD
+read -p "Enter dockerhub username:" DOCKER_USERNAME
+read -s -p "Enter dockerhub password: " DOCKER_PASSWORD
 docker build -t $DOCKER_IMAGE_NAME:$DOCKER_TAG .;
 echo "uploading docker container to dockerhub with user $DOCKER_USERNAME"
-docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+echo $DOCKER_PASSWORD | docker login -u="$DOCKER_USERNAME" --password-stdin;
 docker tag $DOCKER_IMAGE_NAME:$DOCKER_TAG nzzonline/$DOCKER_IMAGE_NAME:$DOCKER_TAG;
 docker push nzzonline/$DOCKER_IMAGE_NAME:$DOCKER_TAG;
 echo "done"

--- a/tilesets/index.js
+++ b/tilesets/index.js
@@ -14,9 +14,9 @@ async function downloadTileset(url, path, size) {
   if (response.ok) {
     const progressStream = progress({
       length: size,
-      time: 1000 /* ms */
+      time: 1000 /* ms */,
     });
-    progressStream.on("progress", progress => {
+    progressStream.on("progress", (progress) => {
       console.log(`Progress: ${Math.round(progress.percentage * 10) / 10} %\r`);
     });
     response.body
@@ -61,6 +61,9 @@ async function main() {
         }
       }
     }
+
+    // Keep node process running forever
+    setInterval(() => {}, 1 << 30);
   } catch (error) {
     console.log(error);
   }


### PR DESCRIPTION
This PR makes the script run forever using `setInterval` function. This allows to run the container in rancher2 environment which doesn't support `runOnce` option anymore.