### PR TITLE
Release v1.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Q-locator-map",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Q-locator-map",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/resources/styles/basic/style.json
+++ b/resources/styles/basic/style.json
@@ -92,8 +92,7 @@
       "source-layer": "water",
       "filter": ["==", "$type", "Polygon"],
       "paint": {
-        "fill-color": "{colorWater}",
-        "fill-outline-color": "#e9f5f6"
+        "fill-color": "{colorWater}"
       }
     },
     {

--- a/resources/styles/minimal/style.json
+++ b/resources/styles/minimal/style.json
@@ -59,7 +59,6 @@
       "filter": ["==", "$type", "Polygon"],
       "paint": {
         "fill-color": "{colorWater}",
-        "fill-outline-color": "#a8bdcc",
         "fill-translate": [1, 1],
         "fill-opacity": 0.65
       }

--- a/resources/styles/nature/style.json
+++ b/resources/styles/nature/style.json
@@ -106,7 +106,6 @@
       "filter": ["all", ["==", "class", "wood"]],
       "paint": {
         "fill-color": "{colorForest}",
-        "fill-outline-color": "{colorForest}",
         "fill-opacity": 0.25,
         "fill-translate": [1, 1]
       }
@@ -120,7 +119,6 @@
       "filter": ["all", ["==", "$type", "Polygon"], ["==", "class", "ice"]],
       "paint": {
         "fill-color": "#ffffff",
-        "fill-outline-color": "#ffffff",
         "fill-opacity": {
           "base": 1,
           "stops": [
@@ -149,7 +147,6 @@
       "filter": ["all", ["==", "$type", "Polygon"]],
       "paint": {
         "fill-color": "{colorWater}",
-        "fill-outline-color": "#a8bdcc",
         "fill-translate": [1, 1]
       }
     },


### PR DESCRIPTION
- Removes `fill-outline-color` from water layer

Before:

<img width="670" alt="Screenshot 2021-05-01 at 22 13 41" src="https://user-images.githubusercontent.com/1810384/116794114-fd04d480-aaca-11eb-8b9e-2b48e500dab3.png">

After:

<img width="668" alt="Screenshot 2021-05-01 at 22 13 34" src="https://user-images.githubusercontent.com/1810384/116794118-02621f00-aacb-11eb-8a52-e497182b063e.png">
