### PR TITLE
fix labelsBelowMapOneRow option

### DIFF
--- a/views/Annotations/AnnotationsLegend.svelte
+++ b/views/Annotations/AnnotationsLegend.svelte
@@ -48,11 +48,12 @@
 
 {#if item.options.labelsBelowMap === true}
   <div
-    class="s-q-item__annotation-legend s-font-note {item.options
-      .labelsBelowMapOneRow === true
+    class="s-q-item__annotation-legend s-font-note {item.options.labelsBelowMapOneRow === true
       ? 'q-locator-map-labels--one-row'
       : ''}"
-  >
+    style="{item.options.labelsBelowMapOneRow === true
+      ? 'flex-flow: row wrap;'
+      : ''}">
     {#each numberedLabels as { id, text }}
       <div class="s-q-item__annotation-legend__item">
         <div class="s-q-item__annotation-legend__item__icon">


### PR DESCRIPTION
This is a hotfix for the labelsBelowMapOneRow option.

When the option labelsBelowMapOneRow is active, the container for the labels below the map use `flex-flow: row wrap;` to be rendered in one row. In production we have the issue, that the attribute `flex-direction: column;` from the sophie class `s-q-item__annotation-legend` overwrites this. This hotfix fixes this temporarly.

Affected Q-item: https://q.st.nzz.ch/item/b655903578c08e78086bb70741e740fc